### PR TITLE
Remove duplicate arrow from continue button

### DIFF
--- a/src/components/onboarding/NavigationButtons.tsx
+++ b/src/components/onboarding/NavigationButtons.tsx
@@ -13,7 +13,7 @@ interface NavigationButtonsProps {
 export const NavigationButtons = ({ 
   onNext, 
   onBack, 
-  nextLabel = "Continue →", 
+  nextLabel = "Continue", 
   nextDisabled = false,
   hideBack = false
 }: NavigationButtonsProps) => {


### PR DESCRIPTION
- Removed duplicate arrow from continue button
- Only showing one arrow now